### PR TITLE
Kyle update macros

### DIFF
--- a/macros/macro_10.sbp
+++ b/macros/macro_10.sbp
@@ -11,7 +11,7 @@
 '--- Adjust Standard Macro Variables to Current Tool Units if Needed ---
 '--- Check to make sure Standard Macro Variables have been read
 $sb_standard_variables_PRESENT := 0								  ' Define test variable if it does not exist
-IF $sb_standard_variables_PRESENT == 0 THEN GOTO no_variables
+IF $sb_standard_variables_PRESENT == 0 THEN GOSUB no_variables
 
 ' === Main Program ===
   GOSUB initialize_variables
@@ -68,8 +68,8 @@ run_C3:
 	RETURN
 
 no_variables:
-      PAUSE "Macro #201 defining Standard Macro Variables does not seem to have been run. Quit and Run then try Macro again."
-      END
+    C201
+    RETURN
 
 
 '--- Initialize Variables and Adjust Standard Macro Variables for Current Tool and Conditions as Needed

--- a/macros/macro_2.sbp
+++ b/macros/macro_2.sbp
@@ -21,7 +21,6 @@ GOSUB backOffProx_if_needed
 GOSUB check_plate_clearance
 GOSUB first_home_z_toProx
 GOSUB find_z_zero_plate
-PAUSE .5
 GOSUB finish
 END
 '==============================

--- a/macros/macro_2.sbp
+++ b/macros/macro_2.sbp
@@ -11,7 +11,7 @@
 
 '--- Check to make sure Standard Macro Variables have been read
 $sb_standard_variables_PRESENT := 0								  ' Define test variable if it does not exist
-IF $sb_standard_variables_PRESENT == 0 THEN GOTO no_variables
+IF $sb_standard_variables_PRESENT == 0 THEN GOSUB no_variables
 
 ' === Main Program ===
 GOSUB initialize_variables
@@ -93,8 +93,8 @@ finish:
 		END                           
 
 	no_variables:
-    	PAUSE "Macro #201 defining Standard Macro Variables does not seem to have been run. Quit and Run then try Macro again."
-        END
+        C201
+        RETURN
 
 
 '--- Initialize Variables and Adjust Standard Macro Variables for Current Tool and Conditions as Needed

--- a/macros/macro_2.sbp
+++ b/macros/macro_2.sbp
@@ -58,8 +58,6 @@ find_z_zero_plate:                                              ' Now Offset to 
     RETURN
 
 finish:
-	MZ, &safeZ_pullup - .05										' Trigger location update with a little "finish-wiggle" acknowledgement
-    MZ, &safeZ_pullup
 	PAUSE "Remember to Remove Clip! The following value will be used for Cutter Offset in Homing:  " + $sb_current_cutter_Zoffset
     RETURN
 

--- a/macros/macro_201.sbp
+++ b/macros/macro_201.sbp
@@ -133,7 +133,6 @@ $sb_home_Y               = 0         '- (m3) this would be a special offset from
 $sb_safe_Z               = %(28)     'Temporary retreival from system vars ... see note below
 
 $sb_standard_variables_PRESENT = 1   'CONFIRM ALL READ.
-PAUSE "Standard Macro Variables Read  Confirm => " + $sb_standard_variables_PRESENT
 
 
 '* - FUTURE: ShopBot V-Carve posts currently write an IF statement at the top of file that tests whether file measurement UNITS match current measurement UNITS of tool>

--- a/macros/macro_3.sbp
+++ b/macros/macro_3.sbp
@@ -20,7 +20,6 @@ IF $sb_standard_variables_PRESENT == 0 THEN GOSUB no_variables
 GOSUB initialize_variables
 ' --- Main Program Sequence ---
 Z3    ' zeoring all axes at their current location (sets worst case homing distances)l  ##TABLE BASE?
-GOSUB moveOutFromProx
 GOSUB backOffProx_if_needed
 GOSUB home_z
 GOSUB home_x
@@ -76,10 +75,7 @@ offset_z_cutter:
 
 
 ' --- Checks and Failures ---
-  moveOutFromProx:
-  	  M2, (2 * &homeOff_X), (2 * &homeOff_Y)					' To avoid being stuck behind prox, move XY out 3X offset from location	
-      RETURN
-      
+
   backOffProx_if_needed:                                        ' Managing prox switches is complicated by multiple arrangements
       &proxTriggered = 0
       GOSUB checkProxs

--- a/macros/macro_3.sbp
+++ b/macros/macro_3.sbp
@@ -14,7 +14,7 @@
 
 '--- Check to make sure Standard Macro Variables have been read
 $sb_standard_variables_PRESENT := 0								  ' Define test variable if it does not exist
-IF $sb_standard_variables_PRESENT == 0 THEN GOTO no_variables
+IF $sb_standard_variables_PRESENT == 0 THEN GOSUB no_variables
 
 ' === Main Program ===
 GOSUB initialize_variables
@@ -113,8 +113,8 @@ offset_z_cutter:
       END
 
   no_variables:
-      PAUSE "Macro #201 defining Standard Macro Variables does not seem to have been run. Quit and Run then try Macro again."
-      END
+        C201
+        RETURN
 
 '--- Initialize Variables and Adjust Standard Macro Variables for Current Tool and Conditions as Needed
 initialize_variables:

--- a/macros/macro_79.sbp
+++ b/macros/macro_79.sbp
@@ -11,7 +11,7 @@
 '--- Adjust Standard Macro Variables to Current Tool Units if Needed ---
 '--- Check to make sure Standard Macro Variables have been read
 $sb_standard_variables_PRESENT := 0								  ' Define test variable if it does not exist
-IF $sb_standard_variables_PRESENT == 0 THEN GOTO no_variables
+IF $sb_standard_variables_PRESENT == 0 THEN GOSUB no_variables
 
 ' === Main Program ===
   GOSUB initialize_variables
@@ -28,9 +28,8 @@ Move_to_Position:
   END
 
 no_variables:
-      PAUSE "Macro #201 defining Standard Macro Variables does not seem to have been run. Quit and Run then try Macro again."
-      END
-
+    C201
+    RETURN
 
 '--- Initialize Variables and Adjust Standard Macro Variables for Current Tool and Conditions as Needed
 initialize_variables:

--- a/macros/macro_9.sbp
+++ b/macros/macro_9.sbp
@@ -13,7 +13,7 @@
 
 '--- Check to make sure Standard Macro Variables have been read
 $sb_standard_variables_PRESENT := 0								  ' Define test variable if it does not exist
-IF $sb_standard_variables_PRESENT == 0 THEN GOTO no_variables
+IF $sb_standard_variables_PRESENT == 0 THEN GOSUB no_variables
 
 ' === Main Program ===
 GOSUB initialize_variables
@@ -122,8 +122,8 @@ NoChange:
     END
 
 no_variables:
-    PAUSE "Macro #201 defining Standard Macro Variables does not seem to have been run. Quit and Run then try Macro again."
-    END
+    C201
+    RETURN
 
 
 initialize_variables:


### PR DESCRIPTION
These changes address:
https://github.com/FabMo/FabMo-Engine/issues/1012
https://github.com/FabMo/FabMo-Engine/issues/1011
and in part https://github.com/FabMo/FabMo-Engine/issues/993

https://github.com/FabMo/FabMo-Engine/issues/993 may exist in other situations since it appears to have been caused by a pause before a function call.

We also agreed that macro 201 should run just if it has not been ran already.

For testing, I created a fresh build of fabmo using dev-build script and switched to the desktop profile. First, I ran a cut file without running macro 201. It ran properly and did not prompt the user with a dialog box after running. Then I tested that macro 2 ran to completion and did not perform the "finish wiggle". Lastly, I tested that C3 ran properly and did not perform the seemingly unnecessary move away from zero in X and Y.